### PR TITLE
fix minor bug in fitLineFromPixels

### DIFF
--- a/lesson20/src/helpers.cpp
+++ b/lesson20/src/helpers.cpp
@@ -233,7 +233,7 @@ Line fitLineFromPixels(const std::vector<cv::Point2i> &pixels, const cv::Mat &gr
         float lineTotalDist = 0.0f;
 
         for (int pj = 0; pj < pixels.size(); ++pj) {
-            cv::Point2i p = pixels[pi];
+            cv::Point2i p = pixels[pj];
             float distance = line.distanceFromPoint(p.x, p.y); // каждая точка смотрит насколько она далеко от предлагаемой прямой
             float distance2 = line.distance2FromPoint(p.x, p.y);
 


### PR DESCRIPTION
fix a minor bug in fitLineFromPixels, which cause a unexpected line fit result. see the follow pic:
![image](https://github.com/user-attachments/assets/d77a4b66-e404-472b-bd95-fd0077c63341)
when the line fit is correct, everything works as expected
![image](https://github.com/user-attachments/assets/686eb222-a976-4cf1-a7d9-5e3ae8a86b7e)

